### PR TITLE
Minor Fixes

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -133,7 +133,7 @@ export class Database {
 
         return { success: true, ids: [vectorId.toString()] };
       } catch (error) {
-        return { success: false, error: JSON.stringify(error) };
+        return { success: false, error: JSON.stringify(error, Object.getOwnPropertyNames(error)) };
       }
     } else if (input.type === "embedding") {
       const items = input.data.map((context) => {
@@ -148,7 +148,7 @@ export class Database {
 
         return { success: true, ids: items.map((item) => item.id.toString()) };
       } catch (error) {
-        return { success: false, error: JSON.stringify(error) };
+        return { success: false, error: JSON.stringify(error, Object.getOwnPropertyNames(error)) };
       }
     } else {
       try {
@@ -165,7 +165,7 @@ export class Database {
         return { success: true, ids: transformDocuments.map((document) => document.id) };
       } catch (error) {
         console.error(error);
-        return { success: false, error: JSON.stringify(error) };
+        return { success: false, error: JSON.stringify(error, Object.getOwnPropertyNames(error)) };
       }
     }
   }

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect } from "bun:test";
+import { RAGChat } from "./rag-chat";
+import { upstash } from "./models";
+
+describe("Model", () => {
+  test("should raise error when api key is not found", () => {
+    let ran = false;
+    const throws = () => {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const ragChat = new RAGChat({
+          model: upstash("meta-llama/Meta-Llama-3-8B-Instruct", { apiKey: "" }),
+        });
+      } catch (error) {
+        ran = true;
+        throw error;
+      }
+    };
+    expect(throws).toThrow(
+      "Failed to create upstash LLM client: QSTASH_TOKEN not found." +
+        " Pass apiKey parameter or set QSTASH_TOKEN env variable."
+    );
+    expect(ran).toBeTrue();
+  });
+});

--- a/src/models.ts
+++ b/src/models.ts
@@ -31,10 +31,17 @@ export type UpstashChatModel =
 type ModelOptions = Omit<LLMClientConfig, "model">;
 
 export const upstash = (model: UpstashChatModel, options?: Omit<ModelOptions, "baseUrl">) => {
+  const apiKey = process.env.QSTASH_TOKEN ?? options?.apiKey ?? "";
+  if (!apiKey) {
+    throw new Error(
+      "Failed to create upstash LLM client: QSTASH_TOKEN not found." +
+        " Pass apiKey parameter or set QSTASH_TOKEN env variable."
+    );
+  }
   return new LLMClient({
     model,
     baseUrl: "https://qstash.upstash.io/llm/v1",
-    apiKey: process.env.QSTASH_TOKEN ?? options?.apiKey ?? "",
+    apiKey,
     ...options,
   });
 };

--- a/src/nextjs/chat-adapter.ts
+++ b/src/nextjs/chat-adapter.ts
@@ -9,10 +9,7 @@ import { LangChainAdapter, StreamingTextResponse } from "ai";
  *   - isStream: A boolean indicating if the response is a stream.
  * @returns StreamingTextResponse - The adapted response for use with the useChat hook.
  */
-export const aiUseChatAdapter = (response: {
-  output: ReadableStream<string>;
-  isStream: boolean;
-}) => {
+export const aiUseChatAdapter = (response: { output: ReadableStream<string>; isStream: true }) => {
   const wrappedStream = LangChainAdapter.toAIStream(response.output);
   return new StreamingTextResponse(wrappedStream, {});
 };

--- a/src/rag-chat-base.ts
+++ b/src/rag-chat-base.ts
@@ -79,7 +79,7 @@ export class RAGChatBase {
     onChunk?: ChatOptions["onChunk"];
   }): Promise<{
     output: ReadableStream<string>;
-    isStream: boolean;
+    isStream: true;
   }> {
     const stream = (await this.#model.stream([
       new HumanMessage(prompt),

--- a/src/rag-chat.ts
+++ b/src/rag-chat.ts
@@ -15,7 +15,7 @@ type ChatReturnType<T extends Partial<ChatOptions>> = Promise<
   T["streaming"] extends true
     ? {
         output: ReadableStream<string>;
-        isStream: boolean;
+        isStream: true;
       }
     : { output: string; isStream: false }
 >;


### PR DESCRIPTION
This PR addresses the following issues:
- [change default langchain error message when QSTASH_TOKEN is not set](https://github.com/upstash/rag-chat/commit/e6ae29965a6736d931efdfe7c54f3ca061bbb96a)
- [set isStream to true in the streaming case, instead of boolean](https://github.com/upstash/rag-chat/commit/9cdefe004bc1ea94b01d9cc568f899ade049345e)
- [add parameter Object.getOwnPropertyNames(error) to JSON.stringify(error)](https://github.com/upstash/rag-chat/commit/3703a8ad26f3007abfe32adf9b806d63f1ca17fa) 

More details are available in the commit messages.