### PR TITLE
Pass apiKey when creating upstash model

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -41,6 +41,7 @@ export const upstash = (model: UpstashChatModel, options?: Omit<ModelOptions, "b
 
   return new ChatOpenAI({
     modelName: model,
+    apiKey: apiKey,
     ...options,
     streamUsage: false,
     configuration: {


### PR DESCRIPTION
It wasn't possible to create `upstash` model with QSTASH_TOKEN from environment because we didn't pass the apiKey

cc @muhammetssen 