### PR TITLE
Fix: Correct URL reconstruction to properly handle URLs with protocol

### DIFF
--- a/examples/nextjs/chat-to-website/src/app/[...url]/page.tsx
+++ b/examples/nextjs/chat-to-website/src/app/[...url]/page.tsx
@@ -12,7 +12,7 @@ interface PageProps {
 function reconstructUrl({ url }: { url: string[] }) {
   const decodedComponents = url.map((component) => decodeURIComponent(component))
 
-  return decodedComponents.join("/")
+  return decodedComponents.join("//")
 }
 
 const Page = async ({ params }: PageProps) => {


### PR DESCRIPTION
Corrected URL reconstruction to handle protocols properly. 
```console.log of params and reconstructedUrl```
Before the Fix:

	•	Input: ['https%3A', 'example.com']
	•	Output: https:/example.com

After the Fix:

	•	Input: ['https%3A', 'example.com']
	•	Output: https://example.com