### PR TITLE
fix: prevent history revert

### DIFF
--- a/src/rag-chat.ts
+++ b/src/rag-chat.ts
@@ -219,7 +219,6 @@ export class RAGChat {
 
         // Formats the chat history for better accuracy when querying LLM
         const formattedHistory = modifiedChatHistory
-          .reverse()
           .map((message) => {
             return message.role === "user"
               ? `USER MESSAGE: ${message.content}`


### PR DESCRIPTION
We were reverting history from latest to oldest, there is no need for that now. So I'm removing it.