### PR TITLE
Bump llamaindex

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,22 +68,22 @@
     "d3-dsv": "^3.0.1",
     "html-to-text": "^9.0.5",
     "langchain": "^0.2.0",
-    "llamaindex": "^0.5.20",
+    "llamaindex": "^0.6.0",
     "nanoid": "^5.0.7",
     "pdf-parse": "^1.1.1",
     "unstructured-client": "^0.15.1"
   },
   "peerDependencies": {
+    "@langchain/openai": "^0.2.8",
+    "@upstash/ratelimit": "^2.0.2",
     "@upstash/redis": "^1.34.0",
     "@upstash/vector": "^1.1.5",
-    "@upstash/ratelimit": "^2.0.2",
-    "@langchain/openai": "^0.2.8",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
   "optionalDependencies": {
-    "langsmith": "^0.1.41",
+    "@langchain/anthropic": "^0.2.15",
     "@langchain/mistralai": "^0.0.28",
-    "@langchain/anthropic": "^0.2.15"
+    "langsmith": "^0.1.41"
   }
 }


### PR DESCRIPTION
fixes rag-chat install errors caused by mising llamaindex/openai version 1.1.0 on npm.

The problem in a nutshell:
- llamaindex 0.5.20 depends on llamaindex/openai v1.1.0. It was changed to v1.2.0 on llamaindex 0.6.0. [See tha versions here](https://www.npmjs.com/package/llamaindex/v/0.6.0?activeTab=versions).
- [npm for llamaindex/openai only shows 1.2.0](https://www.npmjs.com/package/@llamaindex/openai?activeTab=versions)

By bumping the llamaindex version to 0.6.0, we fix the build errors.