### PR TITLE
Fix URL reading issue in [..url]/page.tsx

### DIFF
--- a/examples/nextjs/chat-to-website/src/app/[...url]/page.tsx
+++ b/examples/nextjs/chat-to-website/src/app/[...url]/page.tsx
@@ -12,7 +12,7 @@ interface PageProps {
 function reconstructUrl({ url }: { url: string[] }) {
   const decodedComponents = url.map((component) => decodeURIComponent(component));
 
-  return decodedComponents.join("//");
+  return decodedComponents.join("/");
 }
 
 const Page = async ({ params }: PageProps) => {


### PR DESCRIPTION
Update page.tsx - replace "//" with "/" in decodedComponents.join() - url was not reading before and the bot wouldn't answer questions correctly.